### PR TITLE
Wrap columns instead of scaling down on mobile devices

### DIFF
--- a/src/pages/style.css
+++ b/src/pages/style.css
@@ -65,10 +65,12 @@ section h1 {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  flex-wrap: wrap;
 }
 
 .column {
   padding-right: 1em;
+  flex: 1 0 33%;
 }
 
 /* Terminal settings */

--- a/src/templates/head.html
+++ b/src/templates/head.html
@@ -1,5 +1,6 @@
 <head>
   <title>Madison Swain-Bowden</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
   <link
     rel="stylesheet"
     href="https://unpkg.com/modern-normalize@3.0.0/modern-normalize.css"


### PR DESCRIPTION
Looks like this on mobile now:

![Screenshot_20241101-002959_Firefox (1)](https://github.com/user-attachments/assets/abe0175a-2a61-47e8-849b-c509348359c5)

Still looks like this on desktop:

![image](https://github.com/user-attachments/assets/8948a2c3-593f-4171-b84b-63d3d7d1822d)


Please try it on your device!