### PR TITLE
Add justfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,17 @@
 
 ## Installation & Building
 
+### Prerequisites
+
+- [`just`](https://just.systems/)
+- [`node`](https://nodejs.org/en/) (see `just node-version` for which version to install)
+
 ### For development
 
-1. `npm install`
-2. `npm run watch` in one terminal, and `npm run serve` in another
+1. `just install`
+2. `just up`
 
 ### To build for publishing
 
-1. `npm install`
-2. `npm run generate`
+1. `just install`
+2. `just generate`

--- a/justfile
+++ b/justfile
@@ -1,0 +1,49 @@
+set dotenv-load := false
+
+# Show all available recipes
+@default:
+    just --list --unsorted
+
+
+###########
+# Version #
+###########
+
+export NODE_VERSION := `grep 'node": ">= ' package.json | awk -F'>= ' '{print $2}' | awk -F'.' '{print $1}'`
+
+# Print the Node.js version specified in `package.json`
+@node-version:
+    echo $NODE_VERSION
+
+
+###############
+# Development #
+###############
+
+# Install dependencies
+install:
+    npm install
+
+alias i := install
+
+# Generate static files
+generate:
+    node ./generate.js
+
+# Serve static files
+serve:
+    npm run serve
+
+# Watch for changes and regenerate static files
+watch: install generate
+    npm run watch
+
+# See: https://stackoverflow.com/a/52033580
+# Had to change SIGINT to INT for `sh` compatibility
+[doc('Spin up both the watcher and the server')]
+up:
+    (trap 'kill 0' INT; just watch & just serve)
+
+# Run prettier
+lint:
+    npm run prettier

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,9 @@
         "http-server": "^14.1.1",
         "onchange": "^7.1.0",
         "prettier": "^3.3.3"
+      },
+      "engines": {
+        "node": ">= 23.0.0"
       }
     },
     "node_modules/@blakeembrey/deque": {

--- a/package.json
+++ b/package.json
@@ -3,10 +3,8 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "generate": "node ./generate.js",
-    "clean": "rm public/*",
     "serve": "http-server public/",
-    "watch": "npm run generate && onchange 'src/**/*' -- npm run generate",
+    "watch": "onchange 'src/**/*' -- just generate",
     "prettier": "prettier --write ./src/**/*"
   },
   "engines": {


### PR DESCRIPTION
This PR adds a `justfile` to the project, which makes dependency management and arcane bash incantations a little easier to manage. I was also able to combine the `watch` and `serve` commands into a single recipe, so they can both be run in the same terminal with a single command.

Because Node/npm only makes some of the commands available within its own context (`onchange`, `http-serve`), those had to remain as `npm run` scripts.
