### PR TITLE
Switch to running CI on pull requests

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1,8 +1,8 @@
 name: Run CI & linting checks
 
 on:
-  # Runs on pushes targeting the default branch
-  push:
+  # Runs on pull requests targeting the default branch
+  pull_request:
     branches:
       - main
 


### PR DESCRIPTION
Silly mistake from me! I thought it wasn't showing up on the first PR just because the workflow hadn't been merged yet.
