### PR TITLE
Add an exit command, make appendSpan return span

### DIFF
--- a/src/static/term.js
+++ b/src/static/term.js
@@ -33,11 +33,16 @@ const View = ({ onCommand }) => {
     append: function ($el) {
       $terminal.append($el);
     },
-    /** @param {string} content */
+    /**
+     * Appends a span with the given content to the terminal.
+     * @param {string} content
+     * @returns {HTMLSpanElement}
+     */
     appendSpan: function (content) {
       const $span = document.createElement("span");
       $span.innerText = content;
       this.append($span);
+      return $span;
     },
     prompt: function () {
       const $prompt = /** @type {HTMLElement} */ (
@@ -185,6 +190,30 @@ const view = View({
           view.appendSpan(
             options[Math.floor(Math.random() * options.length)] || "",
           );
+        }
+        break;
+
+      case "exit":
+        {
+          const goodbyeMessages = [
+              "Logging arf!",
+              "Session terminated...but I'll miss you 🥺",
+              "Goodbye, friend! 🐾",
+          ];
+          const message = goodbyeMessages[Math.floor(Math.random() * goodbyeMessages.length)] || "Goodbye!";
+
+          // Create styled goodbye message
+          const $goodbye = view.appendSpan(message)
+          $goodbye.style.fontWeight = "bold";
+          view.append(document.createElement("br"));
+          view.append(document.createElement("br"));
+          // A-la 3 body problem ^x^
+          const $logoff = view.appendSpan("We invite you to log on again.");
+          $logoff.style.color = "#8BC34A";
+          $logoff.style.fontStyle = "italic";
+
+          // Prevent new prompt from appearing by replacing the prompt function
+          view.prompt = () => {}
         }
         break;
 


### PR DESCRIPTION
This adds a cute exit message to the terminal:

![image](https://github.com/user-attachments/assets/d1c44db4-d6ff-49ff-83ef-5171cb839a3c)


I also wanted to make adding & manipulating a span easier, so I changed the function signature of `appendSpan` to enable returning the span that gets created.
