### PR TITLE
Emulate blog subdirectory for posts

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -5,6 +5,7 @@ import {
   writeFileSync,
   rmSync,
   mkdirSync,
+  statSync,
 } from "fs";
 import { join as joinPath } from "path";
 import { marked } from "marked";
@@ -27,19 +28,29 @@ const STATIC_DIR = "static";
 // Compose HTML
 {
   // Turn files into embeddable markup to be exposed as virtual "files" in the terminal.
-  const files = readdirSync(joinPath(SOURCE_PATH, FILES_DIR))
+  const files = readdirSync(joinPath(SOURCE_PATH, FILES_DIR), {
+    recursive: true,
+  })
+    .filter(
+      (file) =>
+        !statSync(
+          joinPath(SOURCE_PATH, FILES_DIR, file.toString()),
+        ).isDirectory(),
+    )
     .map(
-      (filename) =>
+      (filepath) =>
         /** @type {[string, string]} */ ([
-          filename,
-          readFileSync(joinPath(SOURCE_PATH, FILES_DIR, filename)).toString(),
-        ])
+          filepath,
+          readFileSync(
+            joinPath(SOURCE_PATH, FILES_DIR, filepath.toString()),
+          ).toString(),
+        ]),
     )
     .map(
       ([filename, content]) =>
         `<div data-name="${filename}">
   ${marked.parse(content, { async: false })}
-</div>`
+</div>`,
     )
     .join("\n");
   const html = readFileSync(joinPath(SOURCE_PATH, "index.html")).toString();

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -99,6 +99,10 @@ a.prompt-link {
   outline: none;
 }
 
+.terminal-ls {
+  list-style-type: none;
+}
+
 .mastodon-verify {
   height: 0px;
   width: 0px;

--- a/src/static/term.js
+++ b/src/static/term.js
@@ -146,6 +146,9 @@ const files = (() => {
   return fileMap;
 })();
 
+/** @type {"/" | "blog"} */
+let pwd = "/";
+
 const view = View({
   onCommand: (input) => {
     const argv = input.split(" ");
@@ -161,7 +164,8 @@ const view = View({
             view.appendSpan("You're a kitty!");
             break;
           }
-          const file = files[argv[1] || ""];
+          const file =
+            pwd === "blog" ? files[`blog/${argv[1]}`] : files[argv[1] || ""];
 
           if (!file) {
             view.appendSpan(`File not found: ${argv[1]}`);
@@ -185,7 +189,19 @@ const view = View({
       case "ls":
         {
           const $list = document.createElement("ul");
-          Object.keys(files).forEach((file) => {
+          $list.className = "terminal-ls";
+          const filesList =
+            pwd === "blog" || (pwd === "/" && argv[1] === "blog")
+              ? Object.keys(files)
+                  .filter((file) => file.startsWith("blog/"))
+                  .map((file) => file.replace("blog/", ""))
+              : [
+                  ...Object.keys(files).filter(
+                    (file) => !file.startsWith("blog/"),
+                  ),
+                  "blog/",
+                ];
+          filesList.forEach((file) => {
             const $entry = document.createElement("li");
             $entry.innerText = file;
             $list.append($entry);
@@ -193,6 +209,24 @@ const view = View({
           view.append($list);
         }
         break;
+      case "pwd": {
+        view.appendSpan(pwd);
+        break;
+      }
+      case "cd": {
+        console.log(argv);
+        if (argv.length === 1) {
+          pwd = "/";
+        } else if (pwd === "/" && argv[1] === "blog") {
+          pwd = "blog";
+        } else if (argv[1] === "/" || (pwd === "blog" && argv[1] === "..")) {
+          pwd = "/";
+        } else {
+          view.appendSpan(`cd: no such file or directory: ${argv[1]}`);
+        }
+
+        break;
+      }
 
       case "lsb_release":
       case "uname":
@@ -256,7 +290,7 @@ view.prompt();
 // Skip the animation if the URL params include "skip"
 if (window.location.search.startsWith("?post=")) {
   const postName = window.location.search.replace(`?post=`, "");
-  await view.animate(`cat ${postName}.md`);
+  await view.animate(`cat blog/${postName}.md`);
 } else if (!window.location.search.includes("?skip")) {
   await view.animate("cat about.md");
   await view.animate("cat projects.md");


### PR DESCRIPTION
It works, but gosh it's janky. I'm not terribly proud of it. Give it a try and let me know if it's satisfactory. It almost feels worth it to implement actual "subdirectories" properly instead of just pretending like this one subdirectory exists.

<img width="552" height="629" alt="Screenshot 2026-03-12 at 00 39 07" src="https://github.com/user-attachments/assets/c0d43949-d698-4f4f-8595-c960335e9c69" />

<img width="566" height="253" alt="Screenshot 2026-03-12 at 00 39 37" src="https://github.com/user-attachments/assets/16195082-689c-42a6-a8d6-413020604020" />
